### PR TITLE
fix(CI Script): 优化单行注释判断的正则表达式

### DIFF
--- a/src/test/java/com/google/common/escape/ArrayBasedUnicodeEscaperTest.java
+++ b/src/test/java/com/google/common/escape/ArrayBasedUnicodeEscaperTest.java
@@ -28,7 +28,7 @@ public class ArrayBasedUnicodeEscaperTest {
     }
 
     private String singleline(String content) {
-        return "//\\s*" + content;
+        return "//\\s*\\*?\\s*" + content;
     }
 
     private String multiline(String content) {


### PR DESCRIPTION
问题出现于块注释改为行注释时，我仅使用了快捷键来修改，此时注释中的*是保留的，原正则表达式中只判断了空格，没有判断*，CI不予通过

<!--
NOTE: if you are not playing the game, but contributing code to this repository,
Please set the base branch of the pull request to `dev`.

注意：如果你不是在玩游戏，而是向这个仓库贡献代码，请将pull request的目标分支设置为`dev`。
-->
